### PR TITLE
Use RenderTree for tree display

### DIFF
--- a/src/pickpack/__init__.py
+++ b/src/pickpack/__init__.py
@@ -124,7 +124,7 @@ class PickPacker:
                 self.output_format = OutputMode[self.output_format]
             except KeyError:
                 raise ValueError('Invalid output_format property. If it is a str, it must be either "nodeindex", "nameindex", "nodeonly", or "nameonly"')
-        if not isinstance(self.output_format, OutputMode):
+        elif not isinstance(self.output_format, OutputMode):
             raise TypeError('Invalid output_format property type. Must be OutputMode or str (nodeindex, nameindex, nodeonly, or nameonly)')
         
         if not isinstance(self.indicator_parentheses_design, tuple) or len(self.indicator_parentheses_design) != 2 or not isinstance(self.indicator_parentheses_design[0], str) or not isinstance(self.indicator_parentheses_design[1], str):

--- a/src/pickpack/__init__.py
+++ b/src/pickpack/__init__.py
@@ -280,7 +280,7 @@ class PickPacker:
         else:
             return self.index_single_select()
 
-    def get_selected(self) -> AnyNode:
+    def get_selected(self) -> AnyNode | list[AnyNode]:
         """return the current selected option as a tuple: (option, index)
            or as a list of tuples (in case multiselect is True)
         """
@@ -352,7 +352,7 @@ class PickPacker:
 
         screen.refresh()
 
-    def run_loop(self, screen: window) -> AnyNode:
+    def run_loop(self, screen: window) -> AnyNode | list[AnyNode]:
         while True:
             self.draw(screen)
             c: int = screen.getch()
@@ -382,16 +382,16 @@ class PickPacker:
             # Curses failed to initialize color support, eg. when TERM=vt100
             curses.initscr()
 
-    def _start(self, screen: window) -> AnyNode:
+    def _start(self, screen: window) -> AnyNode | list[AnyNode]:
         self.config_curses()
         return self.run_loop(screen)
 
-    def start(self) -> AnyNode:
+    def start(self) -> AnyNode | list[AnyNode]:
         """Starts the interaction with the user"""
         return curses.wrapper(self._start)
 
 
-def pickpack(*args, **kwargs) -> AnyNode:
+def pickpack(*args, **kwargs) -> AnyNode | list[AnyNode]:
     """Construct and start a :class:`PickPacker <PickPacker>`.
 
     Usage::

--- a/src/pickpack/__init__.py
+++ b/src/pickpack/__init__.py
@@ -375,7 +375,7 @@ class PickPacker:
             curses.initscr()
 
     def _start(self, screen: window) -> AnyNode:
-        PickPacker.config_curses()
+        self.config_curses()
         return self.run_loop(screen)
 
     def start(self) -> AnyNode:

--- a/src/pickpack/__init__.py
+++ b/src/pickpack/__init__.py
@@ -72,6 +72,9 @@ class PickPacker:
     output_format: OutputMode = OutputMode.NodeIndex
     # the default is not perfect, but good enough for most cases
     options_map_func: Callable[[_T], Node] | None = lambda o: Node(str(o))
+    foreground: int = curses.COLOR_WHITE
+    background: int = curses.COLOR_GREEN
+    # internal fields
     all_selected: list[int] = field(init=False, default_factory=list)
     custom_handlers: dict[int, Callable[[PickPacker], Any]] = field(init=False, default_factory=dict)
     index: int = field(init=False, default=0)
@@ -353,16 +356,14 @@ class PickPacker:
                 if ret := self.custom_handlers[c](self):
                     return ret
 
-    @staticmethod
-    def config_curses() -> None:
+    def config_curses(self) -> None:
         try:
             # use the default colors of the terminal
             curses.use_default_colors()
             # hide the cursor
             curses.curs_set(0)
             # add some color for multi_select
-            # @todo make colors configurable
-            curses.init_pair(1, curses.COLOR_GREEN, curses.COLOR_WHITE)
+            curses.init_pair(1, self.foreground, self.background)
         except curses.error:
             # Curses failed to initialize color support, eg. when TERM=vt100
             curses.initscr()

--- a/src/pickpack/__init__.py
+++ b/src/pickpack/__init__.py
@@ -83,7 +83,7 @@ class PickPacker:
 
         # Check for correct options_map_func and build tree
         if self.options_map_func is None and isinstance(self.options, list):
-            raise Exception('options_map_func that maps list items to Node objects is required when passing options of type list')
+            raise ValueError('options_map_func that maps list items to Node objects is required when passing options of type list')
         elif self.options_map_func is not None and not callable(self.options_map_func):
             raise TypeError('options_map_func must be a callable function')
         elif self.options_map_func is not None and callable(self.options_map_func) and isinstance(self.options, list):
@@ -131,7 +131,7 @@ class PickPacker:
                 self.check_children(child)
     
     def check_ancestors(self, node: Node):
-        while (node is not None and node.parent):
+        while node is not None and node.parent:
             all_checked = 1
             for child in node.parent.children:
                 all_checked = all_checked * (child.index in self.all_selected)
@@ -149,7 +149,7 @@ class PickPacker:
                 self.uncheck_children(child)
 
     def uncheck_ancestors(self, node: Node):
-        while (node is not None and node.parent):
+        while node is not None and node.parent:
             try:
                 self.all_selected.remove(node.parent.index)
                 node = node.parent

--- a/src/pickpack/__init__.py
+++ b/src/pickpack/__init__.py
@@ -235,7 +235,7 @@ class PickPacker:
         nameonly = bool(self.output_format)
 
         if self.multiselect:
-            return_tuples: list[NodeWithIndex] = []
+            return_tuples: list[tuple[str | Node, int]] = []    
             if self.output_leaves_only:
                 for selected in self.all_selected:
                     node = find_by_index(self.options.node, selected)

--- a/src/pickpack/__init__.py
+++ b/src/pickpack/__init__.py
@@ -23,10 +23,15 @@ KEYS_SELECT = (curses.KEY_RIGHT, ord(' '))
 
 
 class OutputMode(enum.IntEnum):
+    """Changes how the selected entry is returned"""
     NodeIndex = 0
+    """Returns the selected node and it's index: [(Node('name'), index)]"""
     NameIndex = 1
+    """Returns the name of the selected node and it's index: [('name', index)]"""
     NodeOnly = 2
+    """Returns only the selected node: [Node('name')]"""
     NameOnly = 3
+    """Returns only the name of the selected node: ['name']"""
 
 
 @dataclass
@@ -39,7 +44,7 @@ class PickPacker:
     :param multiselect: (optional) if true its possible to select multiple values by hitting SPACE; defaults to False
     :param singleselect_output_include_children: (optional) if true, output will include all children of the selected node, as well as the node itself; defaults to False
     :param output_leaves_only: (optional) if true, only leaf nodes will be returned; for singleselect mode, singleselect_output_include_children MUST be True; defaults to False
-    :param output_format: (optional) allows for customising output format. "nodeindex" = [(Node('name'), index)]; "nameindex" = [('name', index)]; "nodeonly" = [Node('name')]; "nameonly" = ['name']; default is "nodeindex"
+    :param output_format: (optional) allows for customising output format.
     :param indicator: (optional) custom the selection indicator
     :param indicator_parentheses: (optional) include/remove parentheses around selection indicator; defaults to True
     :param default_index: (optional) set this if the default selected option is not the first one
@@ -101,7 +106,7 @@ class PickPacker:
 
         # Define output format
         if not isinstance(self.output_format, OutputMode):
-            raise TypeError('Invalid output_format property type. Must be OutputMode ("nodeindex", "nameindex", "nodeonly" or "nameonly")')
+            raise TypeError('Invalid output_format property type. Must be OutputMode (nodeindex, nameindex, nodeonly, or nameonly)')
 
         self.index = self.default_index
 

--- a/src/pickpack/__init__.py
+++ b/src/pickpack/__init__.py
@@ -74,8 +74,8 @@ class PickPacker:
     options_map_func: Callable[[_T], Node] | None = lambda o: Node(str(o))
     all_selected: list[int] = field(init=False, default_factory=list)
     custom_handlers: dict[int, Callable[[PickPacker], Any]] = field(init=False, default_factory=dict)
-    index: int = 0
-    scroll_top: int = 0
+    index: int = field(init=False, default=0)
+    scroll_top: int = field(init=False, default=0)
 
     def __post_init__(self):
         # Check for correct number of elements

--- a/src/pickpack/__init__.py
+++ b/src/pickpack/__init__.py
@@ -238,14 +238,13 @@ class PickPacker:
     def index_multi_select(self) -> list[NodeWithIndex]:
         nodes: list[tuple[str | Node, int]] = []
         
-        if self.output_leaves_only:
-            for selected in self.all_selected:
+        for selected in self.all_selected:
+            if self.output_leaves_only:
                 node: Node = find_by_index(self.options.node, selected)
                 nodes.extend([(leaf, leaf.index) for leaf in get_leaves_only(node) if (leaf, leaf.index) not in nodes])
-        else:
-            for selected in self.all_selected:
+            else:
                 nodes.append((find_by_index(self.options.node, selected), selected))
-            
+        
         if self.name_only:
             nodes = [(n[0].name, n[1]) for n in nodes]
         

--- a/src/pickpack/__init__.py
+++ b/src/pickpack/__init__.py
@@ -6,7 +6,7 @@ import curses
 import enum
 from _curses import window
 from dataclasses import dataclass, field
-from typing import Any, Callable, TypeAlias, TypeVar
+from typing import Any, Callable, TypeVar, Union
 
 from anytree import Node, RenderTree
 
@@ -19,10 +19,10 @@ KEYS_ENTER = (curses.KEY_ENTER, ord('\n'), ord('\r'))
 KEYS_UP = (curses.KEY_UP, ord('k'))
 KEYS_DOWN = (curses.KEY_DOWN, ord('j'))
 KEYS_SELECT = (curses.KEY_RIGHT, ord(' '))
-
-NodeWithIndex: TypeAlias = tuple[str | Node, int]
-NodeNameOnly: TypeAlias = str | Node
-AnyNode: TypeAlias = NodeNameOnly | NodeWithIndex
+    
+NodeWithIndex = tuple[Union[str, Node], int]
+NodeNameOnly = Union[str, Node]
+AnyNode = Union[NodeNameOnly, NodeWithIndex]
 
 _T = TypeVar("_T")
 

--- a/src/pickpack/__init__.py
+++ b/src/pickpack/__init__.py
@@ -57,7 +57,7 @@ class PickPacker:
     singleselect_output_include_children: bool = False
     output_leaves_only: bool = False
     output_format: str = "nodeindex"
-    options_map_func: Optional[Callable[[Dict], Node]] = None
+    options_map_func: Optional[Callable[[Dict], Node]] = lambda object: Node(object)
     all_selected: List[str] = field(init=False, default_factory=list)
     custom_handlers: Dict[str, Callable[["PickPacker"], str]] = field(
         init=False, default_factory=dict

--- a/src/pickpack/__init__.py
+++ b/src/pickpack/__init__.py
@@ -22,11 +22,11 @@ KEYS_DOWN = (curses.KEY_DOWN, ord('j'))
 KEYS_SELECT = (curses.KEY_RIGHT, ord(' '))
 
 
-class OutputMode(enum.Enum):
-    nodeindex = 0
-    nameindex = 1
-    nodeonly = 2
-    nameonly = 3
+class OutputMode(enum.IntEnum):
+    NodeIndex = 0
+    NameIndex = 1
+    NodeOnly = 2
+    NameOnly = 3
 
 
 @dataclass
@@ -56,8 +56,8 @@ class PickPacker:
     min_selection_count: int = 0
     singleselect_output_include_children: bool = False
     output_leaves_only: bool = False
-    output_format: str = "nodeindex"
-    options_map_func: Optional[Callable[[Dict], Node]] = lambda object: Node(object)
+    output_format: OutputMode = OutputMode.NodeIndex
+    options_map_func: Optional[Callable[[Dict], Node]] = lambda o: Node(o)
     all_selected: List[str] = field(init=False, default_factory=list)
     custom_handlers: Dict[str, Callable[["PickPacker"], str]] = field(
         init=False, default_factory=dict
@@ -100,13 +100,8 @@ class PickPacker:
             self.options.node.name = self.root_name
 
         # Define output format
-        if isinstance(self.output_format, str):
-            try:
-                self.output_format = OutputMode[self.output_format].value
-            except KeyError:
-                raise ValueError('Invalid output_format property. Must be "nodeindex", "nameindex", "nodeonly" or "nameonly"')
-        else:
-            raise TypeError('Invalid output_format property type. Must be string ("nodeindex", "nameindex", "nodeonly" or "nameonly")')
+        if not isinstance(self.output_format, OutputMode):
+            raise TypeError('Invalid output_format property type. Must be OutputMode ("nodeindex", "nameindex", "nodeonly" or "nameonly")')
 
         self.index = self.default_index
 

--- a/src/pickpack/__init__.py
+++ b/src/pickpack/__init__.py
@@ -49,7 +49,7 @@ class PickPacker:
     :param multiselect: (optional) if true its possible to select multiple values by hitting SPACE; defaults to False
     :param singleselect_output_include_children: (optional) if true, output will include all children of the selected node, as well as the node itself; defaults to False
     :param output_leaves_only: (optional) if true, only leaf nodes will be returned; for singleselect mode, singleselect_output_include_children MUST be True; defaults to False
-    :param output_format: (optional) allows for customising output format.
+    :param output_format: (optional) allows for customising output format. Can be of type OutputMode or str: "nodeindex" = [(Node('name'), index)]; "nameindex" = [('name', index)]; "nodeonly" = [Node('name')]; "nameonly" = ['name']; default is "nodeindex"
     :param indicator: (optional) custom the selection indicator
     :param indicator_parentheses: (optional) include/remove parentheses around selection indicator; defaults to True
     :param indicator_parentheses_design: (optional) the design of the parentheses for the indicator; defaults to '("(", ")")'
@@ -235,7 +235,7 @@ class PickPacker:
         nameonly = bool(self.output_format)
 
         if self.multiselect:
-            return_tuples: list[tuple[str | Node, int]] = []    
+            return_tuples: list[tuple[str | Node, int]] = []
             if self.output_leaves_only:
                 for selected in self.all_selected:
                     node = find_by_index(self.options.node, selected)

--- a/src/pickpack/anytree_utils.py
+++ b/src/pickpack/anytree_utils.py
@@ -1,17 +1,16 @@
-''' anytree_utils.py '''
-
-from typing import Optional
+""" anytree_utils.py """
 
 from anytree import Node, RenderTree, find
 
 
-# Add index property to tree nodes
-def add_indices(tree:RenderTree):
+def add_indices(tree: RenderTree) -> None:
+    """Add index property to tree nodes"""
     for index, row in enumerate(tree):
         row.node.index = index
 
-# Count all leaf (childless) nodes under specified node
-def count_leaves(node:Node, acc: int = 0) -> int:
+
+def count_leaves(node: Node, acc: int = 0) -> int:
+    """Count all leaf (childless) nodes under specified node"""
     if node.children:
         for child in node.children:
             acc += count_leaves(child)
@@ -19,32 +18,36 @@ def count_leaves(node:Node, acc: int = 0) -> int:
         acc += 1
     return acc
 
-# Count all nodes in tree under specified node
-def count_nodes(node:Node, acc: int = 0) -> int:
+
+def count_nodes(node: Node, acc: int = 0) -> int:
+    """Count all nodes in tree under specified node"""
     if node.children:
         for child in node.children:
             acc += count_nodes(child)
     return acc + 1
 
-# Find node using self-defined index property
-def find_by_index(n: Node, index: int) -> Optional[Node]:
-        return find(n, filter_= lambda n : n.index == index)
 
-# Create list of node and all of its descendents (INCLUDES NODE ITSELF at list[0])
-def get_descendants(node:Node, leaves: list[Node] = None) -> list[Node]:
+def find_by_index(node: Node, index: int) -> Node | None:
+    """Find node using self-defined index property"""
+    return find(node, filter_=lambda n: n.index == index)
+
+
+def get_descendants(node: Node, leaves: list[Node] = None) -> list[Node]:
+    """Create list of node and all of its descendants (INCLUDES NODE ITSELF at index 0)"""
     if leaves is None:
         leaves = []
     
     leaves.append(node)
-
+    
     if node.children:
         for child in node.children:
             leaves = get_descendants(child, leaves)
-
+    
     return leaves
 
-# Create list of only leaf (childless) nodes under specified node
-def get_leaves_only(node:Node, leaves: list[Node] = None) -> list[Node]:
+
+def get_leaves_only(node: Node, leaves: list[Node] = None) -> list[Node]:
+    """Create list of only leaf (childless) nodes under specified node"""
     if leaves is None:
         leaves = []
     

--- a/src/pickpack/anytree_utils.py
+++ b/src/pickpack/anytree_utils.py
@@ -1,4 +1,5 @@
 """ anytree_utils.py """
+from __future__ import annotations
 
 from anytree import Node, RenderTree, find
 

--- a/src/pickpack/anytree_utils.py
+++ b/src/pickpack/anytree_utils.py
@@ -54,7 +54,6 @@ def get_leaves_only(node: Node, leaves: list[Node] = None) -> list[Node]:
     if node.children:
         for child in node.children:
             leaves = get_leaves_only(child, leaves)
-    else:
-        if node not in leaves:
-            leaves.append(node)
+    elif node not in leaves:
+        leaves.append(node)
     return leaves

--- a/tests/test_pickpack.py
+++ b/tests/test_pickpack.py
@@ -4,7 +4,7 @@ from pickpack import PickPacker, OutputMode
 
 
 def test_move_up_down():
-    title = "Please choose an option: "
+    title = "Please choose an option:"
     c1 = Node("child1")
     c2 = Node("child2")
     p1 = Node("parent", children=[c1, c2])
@@ -28,7 +28,7 @@ def test_default_index():
 
 
 def test_get_lines():
-    title = "Please choose an option: "
+    title = "Please choose an option:"
     c1 = Node("child1")
     c2 = Node("child2")
     p1 = Node("parent", children=[c1, c2])
@@ -40,7 +40,7 @@ def test_get_lines():
 
 
 def test_parenthesis():
-    title = "Please choose an option: "
+    title = "Please choose an option:"
     c1 = Node("child1")
     c2 = Node("child2")
     p1 = Node("parent", children=[c1, c2])
@@ -62,7 +62,7 @@ def test_no_title():
 
 
 def test_multi_select():
-    title = "Please choose one or more options: "
+    title = "Please choose one or more options:"
     c1 = Node("child1")
     c2 = Node("child2")
     p1 = Node("parent", children=[c1, c2])
@@ -77,7 +77,7 @@ def test_multi_select():
 
 
 def test_options_map_func():
-    title = "Please choose an option: "
+    title = "Please choose an option:"
     options = [{"label": "option1"}, {"label": "option2"}, {"label": "option3"}]
 
     def get_node(option):
@@ -90,7 +90,7 @@ def test_options_map_func():
 
 
 def test_list_no_func():
-    title = "Please choose an option: "
+    title = "Please choose an option:"
     options = [{"label": "option1"}, {"label": "option2"}, {"label": "option3"}]
 
     # no function is fine, the default handles it
@@ -100,7 +100,7 @@ def test_list_no_func():
 
 
 def test_output_format():
-    title = "Please choose one or more options: "
+    title = "Please choose one or more options:"
     c1 = Node("child1")
     c2 = Node("child2")
     p1 = Node("parent", children=[c1, c2])
@@ -149,7 +149,7 @@ def test_output_format():
 
 
 def test_root_name():
-    title = "Please choose an option: "
+    title = "Please choose an option:"
     options = [{"label": "option1"}, {"label": "option2"}, {"label": "option3"}]
 
     def get_node(option):
@@ -162,7 +162,7 @@ def test_root_name():
 
 
 def test_leaves_only():
-    title = "Please choose an option: "
+    title = "Please choose an option:"
     options = [{"label": "option1"}, {"label": "option2"}, {"label": "option3"}]
 
     def get_node(option):
@@ -183,7 +183,7 @@ def test_leaves_only():
 
 
 def test_include_children():
-    title = "Please choose an option: "
+    title = "Please choose an option:"
     options = [{"label": "option1"}, {"label": "option2"}, {"label": "option3"}]
 
     def get_node(option):
@@ -191,6 +191,22 @@ def test_include_children():
 
     picker = PickPacker(options, title, options_map_func=get_node, output_format=OutputMode.NameIndex, singleselect_output_include_children=True)
     assert picker.get_selected() == [("Select all", 0), ("option1", 1), ("option2", 2), ("option3", 3)]
+
+
+def test_custom_indicator_parentheses():
+    title = "Please choose an option:"
+    options = ["option1", "option2", "option3"]
+    
+    picker = PickPacker(options, title, indicator_parentheses_design=(">>", "<<"))
+    assert picker.get_lines() == (['Please choose an option:', '', '>>*<<  Select all', '>> << ├──  option1', '>> << ├──  option2', '>> << └──  option3'], 3)
+
+
+def test_custom_indicator_parentheses_and_indicator():
+    title = "Please choose an option:"
+    options = ["option1", "option2", "option3"]
+    
+    picker = PickPacker(options, title, indicator_parentheses_design=(">>", "<<"), indicator="==")
+    assert picker.get_lines() == (['Please choose an option:', '', '>>==<<  Select all', '>>  << ├──  option1', '>>  << ├──  option2', '>>  << └──  option3'], 3)
 
 
 if __name__ == "__main__":

--- a/tests/test_pickpack.py
+++ b/tests/test_pickpack.py
@@ -1,3 +1,5 @@
+import curses
+
 import pytest
 from anytree import Node, RenderTree
 from pickpack import PickPacker, OutputMode
@@ -223,5 +225,5 @@ if __name__ == "__main__":
     test_leaves_only()
     test_include_children()
     test_custom_indicator_parentheses()
-    test_custom_indicator_parentheses_and_indicator()       
+    test_custom_indicator_parentheses_and_indicator()
     print("Tests concluded")

--- a/tests/test_pickpack.py
+++ b/tests/test_pickpack.py
@@ -7,7 +7,7 @@ def test_move_up_down():
     title = "Please choose an option: "
     c1 = Node("child1")
     c2 = Node("child2")
-    p1 = Node("parent", children=[c1,c2])
+    p1 = Node("parent", children=[c1, c2])
     options = RenderTree(p1)
     picker = PickPacker(options, title, output_format="nameindex")
     picker.move_up()
@@ -16,53 +16,57 @@ def test_move_up_down():
     picker.move_down()
     assert picker.get_selected() == ("child1", 1)
 
+
 def test_default_index():
     title = "Please choose an option: "
     c1 = Node("child1")
     c2 = Node("child2")
-    p1 = Node("parent", children=[c1,c2])
+    p1 = Node("parent", children=[c1, c2])
     options = RenderTree(p1)
     picker = PickPacker(options, title, output_format="nameindex", default_index=1)
     assert picker.get_selected() == ("child1", 1)
+
 
 def test_get_lines():
     title = "Please choose an option: "
     c1 = Node("child1")
     c2 = Node("child2")
-    p1 = Node("parent", children=[c1,c2])
-    options = RenderTree(p1)    
+    p1 = Node("parent", children=[c1, c2])
+    options = RenderTree(p1)
     picker = PickPacker(options, title, indicator="*", indicator_parentheses=False)
     lines, current_line = picker.get_lines()
-    assert lines == [title, "", "* parent", "     └── child1", "     └── child2"]
+    assert lines == [title, "", "*  parent", "  ├──  child1", "  └──  child2"]
     assert current_line == 3
+
 
 def test_parenthesis():
     title = "Please choose an option: "
     c1 = Node("child1")
     c2 = Node("child2")
-    p1 = Node("parent", children=[c1,c2])
-    options = RenderTree(p1)    
+    p1 = Node("parent", children=[c1, c2])
+    options = RenderTree(p1)
     picker = PickPacker(options, title, indicator="*")
     lines, current_line = picker.get_lines()
-    assert lines == [title, "", "(*) parent", "( )    └── child1", "( )    └── child2"]
+    assert lines == [title, "", "(*)  parent", "( ) ├──  child1", "( ) └──  child2"]
     assert current_line == 3
 
+
 def test_no_title():
-    title = "Please choose an option: "
     c1 = Node("child1")
     c2 = Node("child2")
-    p1 = Node("parent", children=[c1,c2])
-    options = RenderTree(p1)  
+    p1 = Node("parent", children=[c1, c2])
+    options = RenderTree(p1)
     picker = PickPacker(options)
     lines, current_line = picker.get_lines()
     assert current_line == 1
+
 
 def test_multi_select():
     title = "Please choose one or more options: "
     c1 = Node("child1")
     c2 = Node("child2")
-    p1 = Node("parent", children=[c1,c2])
-    options = RenderTree(p1)  
+    p1 = Node("parent", children=[c1, c2])
+    options = RenderTree(p1)
     picker = PickPacker(options, title, multiselect=True, min_selection_count=1, output_format="nameindex")
     assert picker.get_selected() == []
     picker.mark_index()
@@ -70,6 +74,7 @@ def test_multi_select():
     picker.move_down()
     picker.mark_index()
     assert picker.get_selected() == [("child2", 2)]
+
 
 def test_options_map_func():
     title = "Please choose an option: "
@@ -80,22 +85,26 @@ def test_options_map_func():
 
     picker = PickPacker(options, title, indicator="*", options_map_func=get_node, output_format="nameindex")
     lines, current_line = picker.get_lines()
-    assert lines == [title, "", "(*) Select all", "( )    └── option1", "( )    └── option2", "( )    └── option3"]
+    assert lines == [title, "", "(*)  Select all", "( ) ├──  option1", "( ) ├──  option2", "( ) └──  option3"]
     assert picker.get_selected() == ("Select all", 0)
+
 
 def test_list_no_func():
     title = "Please choose an option: "
     options = [{"label": "option1"}, {"label": "option2"}, {"label": "option3"}]
 
-    with pytest.raises(Exception): picker = PickPacker(options, title, indicator="*")
-    with pytest.raises(TypeError): picker = PickPacker(options, title, indicator="*", options_map_func="hello")
+    with pytest.raises(Exception):
+        PickPacker(options, title, indicator="*")
+    with pytest.raises(TypeError):
+        PickPacker(options, title, indicator="*", options_map_func="hello")
+
 
 def test_output_format():
     title = "Please choose one or more options: "
     c1 = Node("child1")
     c2 = Node("child2")
-    p1 = Node("parent", children=[c1,c2])
-    options = RenderTree(p1)  
+    p1 = Node("parent", children=[c1, c2])
+    options = RenderTree(p1)
 
     # Default (nodeindex)
     picker = PickPacker(options, title, multiselect=True, min_selection_count=1)
@@ -138,6 +147,7 @@ def test_output_format():
     with pytest.raises(TypeError):
         picker = PickPacker(options, title, multiselect=True, min_selection_count=1, output_format=1)
 
+
 def test_root_name():
     title = "Please choose an option: "
     options = [{"label": "option1"}, {"label": "option2"}, {"label": "option3"}]
@@ -147,8 +157,9 @@ def test_root_name():
 
     picker = PickPacker(options, title, indicator="*", options_map_func=get_node, output_format="nameindex", root_name="EVERYTHING")
     lines, current_line = picker.get_lines()
-    assert lines == [title, "", "(*) EVERYTHING", "( )    └── option1", "( )    └── option2", "( )    └── option3"]
+    assert lines == [title, "", "(*)  EVERYTHING", "( ) ├──  option1", "( ) ├──  option2", "( ) └──  option3"]
     assert picker.get_selected() == ("EVERYTHING", 0)
+
 
 def test_leaves_only():
     title = "Please choose an option: "
@@ -170,6 +181,7 @@ def test_leaves_only():
     picker = PickPacker(options, title, options_map_func=get_node, output_format="nameindex", output_leaves_only=True, singleselect_output_include_children=True)
     assert picker.get_selected() == [("option1", 1), ("option2", 2), ("option3", 3)]
 
+
 def test_include_children():
     title = "Please choose an option: "
     options = [{"label": "option1"}, {"label": "option2"}, {"label": "option3"}]
@@ -177,8 +189,9 @@ def test_include_children():
     def get_node(option):
         return Node(option.get("label"))
 
-    picker = PickPacker(options, title, options_map_func=get_node, output_format="nameindex",  singleselect_output_include_children=True)
+    picker = PickPacker(options, title, options_map_func=get_node, output_format="nameindex", singleselect_output_include_children=True)
     assert picker.get_selected() == [("Select all", 0), ("option1", 1), ("option2", 2), ("option3", 3)]
+
 
 if __name__ == "__main__":
     test_move_up_down()

--- a/tests/test_pickpack.py
+++ b/tests/test_pickpack.py
@@ -93,8 +93,8 @@ def test_list_no_func():
     title = "Please choose an option: "
     options = [{"label": "option1"}, {"label": "option2"}, {"label": "option3"}]
 
-    with pytest.raises(Exception):
-        PickPacker(options, title, indicator="*")
+    # no function is fine, the default handles it
+    PickPacker(options, title, indicator="*")
     with pytest.raises(TypeError):
         PickPacker(options, title, indicator="*", options_map_func="hello")
 

--- a/tests/test_pickpack.py
+++ b/tests/test_pickpack.py
@@ -11,7 +11,7 @@ def test_move_up_down():
     c2 = Node("child2")
     p1 = Node("parent", children=[c1, c2])
     options = RenderTree(p1)
-    picker = PickPacker(options, title, output_format=OutputMode.NameIndex)
+    picker = PickPacker(options, title, output_format=OutputMode.nameindex)
     picker.move_up()
     assert picker.get_selected() == ("child2", 2)
     picker.move_down()
@@ -25,7 +25,7 @@ def test_default_index():
     c2 = Node("child2")
     p1 = Node("parent", children=[c1, c2])
     options = RenderTree(p1)
-    picker = PickPacker(options, title, output_format=OutputMode.NameIndex, default_index=1)
+    picker = PickPacker(options, title, output_format=OutputMode.nameindex, default_index=1)
     assert picker.get_selected() == ("child1", 1)
 
 
@@ -69,7 +69,7 @@ def test_multi_select():
     c2 = Node("child2")
     p1 = Node("parent", children=[c1, c2])
     options = RenderTree(p1)
-    picker = PickPacker(options, title, multiselect=True, min_selection_count=1, output_format=OutputMode.NameIndex)
+    picker = PickPacker(options, title, multiselect=True, min_selection_count=1, output_format=OutputMode.nameindex)
     assert picker.get_selected() == []
     picker.mark_index()
     assert picker.get_selected() == [("parent", 0), ("child1", 1), ("child2", 2)]
@@ -85,7 +85,7 @@ def test_options_map_func():
     def get_node(option):
         return Node(option.get("label"))
 
-    picker = PickPacker(options, title, indicator="*", options_map_func=get_node, output_format=OutputMode.NameIndex)
+    picker = PickPacker(options, title, indicator="*", options_map_func=get_node, output_format=OutputMode.nameindex)
     lines, _ = picker.get_lines()
     assert lines == [title, "", "(*)  Select all", "( ) ├──  option1", "( ) ├──  option2", "( ) └──  option3"]
     assert picker.get_selected() == ("Select all", 0)
@@ -116,34 +116,37 @@ def test_output_format():
     assert picker.get_selected() == [(c1, 1)]
 
     # nodeindex
-    picker = PickPacker(options, title, multiselect=True, min_selection_count=1, output_format=OutputMode.NodeIndex)
+    picker = PickPacker(options, title, multiselect=True, min_selection_count=1, output_format=OutputMode.nodeindex)
     assert picker.get_selected() == []
     picker.move_down()
     picker.mark_index()
     assert picker.get_selected() == [(c1, 1)]
 
     # nameindex
-    picker = PickPacker(options, title, multiselect=True, min_selection_count=1, output_format=OutputMode.NameIndex)
+    picker = PickPacker(options, title, multiselect=True, min_selection_count=1, output_format=OutputMode.nameindex)
     assert picker.get_selected() == []
     picker.move_down()
     picker.mark_index()
     assert picker.get_selected() == [("child1", 1)]
 
     # nodeonly
-    picker = PickPacker(options, title, multiselect=True, min_selection_count=1, output_format=OutputMode.NodeOnly)
+    picker = PickPacker(options, title, multiselect=True, min_selection_count=1, output_format=OutputMode.nodeonly)
     assert picker.get_selected() == []
     picker.move_down()
     picker.mark_index()
     assert picker.get_selected() == [c1]
 
     # nameonly
-    picker = PickPacker(options, title, multiselect=True, min_selection_count=1, output_format=OutputMode.NameOnly)
+    picker = PickPacker(options, title, multiselect=True, min_selection_count=1, output_format=OutputMode.nameonly)
     assert picker.get_selected() == []
     picker.move_down()
     picker.mark_index()
     assert picker.get_selected() == ["child1"]
+    
+    # str instead of OutputMode
+    PickPacker(options, title, multiselect=True, min_selection_count=1, output_format="nameonly")
 
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         PickPacker(options, title, multiselect=True, min_selection_count=1, output_format="invalid")
 
     with pytest.raises(TypeError):
@@ -157,7 +160,7 @@ def test_root_name():
     def get_node(option):
         return Node(option.get("label"))
 
-    picker = PickPacker(options, title, indicator="*", options_map_func=get_node, output_format=OutputMode.NameIndex, root_name="EVERYTHING")
+    picker = PickPacker(options, title, indicator="*", options_map_func=get_node, output_format=OutputMode.nameindex, root_name="EVERYTHING")
     lines, _ = picker.get_lines()
     assert lines == [title, "", "(*)  EVERYTHING", "( ) ├──  option1", "( ) ├──  option2", "( ) └──  option3"]
     assert picker.get_selected() == ("EVERYTHING", 0)
@@ -171,16 +174,16 @@ def test_leaves_only():
         return Node(option.get("label"))
 
     # Multiselect
-    picker = PickPacker(options, title, multiselect=True, options_map_func=get_node, output_format=OutputMode.NameIndex, output_leaves_only=True)
+    picker = PickPacker(options, title, multiselect=True, options_map_func=get_node, output_format=OutputMode.nameindex, output_leaves_only=True)
     assert picker.get_selected() == []
     picker.mark_index()
     assert picker.get_selected() == [("option1", 1), ("option2", 2), ("option3", 3)]
 
     # Singleselect
     with pytest.raises(ValueError):
-        PickPacker(options, title, options_map_func=get_node, output_format=OutputMode.NameIndex, output_leaves_only=True)
+        PickPacker(options, title, options_map_func=get_node, output_format=OutputMode.nameindex, output_leaves_only=True)
     
-    picker = PickPacker(options, title, options_map_func=get_node, output_format=OutputMode.NameIndex, output_leaves_only=True, singleselect_output_include_children=True)
+    picker = PickPacker(options, title, options_map_func=get_node, output_format=OutputMode.nameindex, output_leaves_only=True, singleselect_output_include_children=True)
     assert picker.get_selected() == [("option1", 1), ("option2", 2), ("option3", 3)]
 
 
@@ -191,7 +194,7 @@ def test_include_children():
     def get_node(option):
         return Node(option.get("label"))
 
-    picker = PickPacker(options, title, options_map_func=get_node, output_format=OutputMode.NameIndex, singleselect_output_include_children=True)
+    picker = PickPacker(options, title, options_map_func=get_node, output_format=OutputMode.nameindex, singleselect_output_include_children=True)
     assert picker.get_selected() == [("Select all", 0), ("option1", 1), ("option2", 2), ("option3", 3)]
 
 

--- a/tests/test_pickpack.py
+++ b/tests/test_pickpack.py
@@ -222,4 +222,6 @@ if __name__ == "__main__":
     test_root_name()
     test_leaves_only()
     test_include_children()
+    test_custom_indicator_parentheses()
+    test_custom_indicator_parentheses_and_indicator()       
     print("Tests concluded")

--- a/tests/test_pickpack.py
+++ b/tests/test_pickpack.py
@@ -1,6 +1,6 @@
 import pytest
 from anytree import Node, RenderTree
-from pickpack import PickPacker
+from pickpack import PickPacker, OutputMode
 
 
 def test_move_up_down():
@@ -9,7 +9,7 @@ def test_move_up_down():
     c2 = Node("child2")
     p1 = Node("parent", children=[c1, c2])
     options = RenderTree(p1)
-    picker = PickPacker(options, title, output_format="nameindex")
+    picker = PickPacker(options, title, output_format=OutputMode.NameIndex)
     picker.move_up()
     assert picker.get_selected() == ("child2", 2)
     picker.move_down()
@@ -23,7 +23,7 @@ def test_default_index():
     c2 = Node("child2")
     p1 = Node("parent", children=[c1, c2])
     options = RenderTree(p1)
-    picker = PickPacker(options, title, output_format="nameindex", default_index=1)
+    picker = PickPacker(options, title, output_format=OutputMode.NameIndex, default_index=1)
     assert picker.get_selected() == ("child1", 1)
 
 
@@ -67,7 +67,7 @@ def test_multi_select():
     c2 = Node("child2")
     p1 = Node("parent", children=[c1, c2])
     options = RenderTree(p1)
-    picker = PickPacker(options, title, multiselect=True, min_selection_count=1, output_format="nameindex")
+    picker = PickPacker(options, title, multiselect=True, min_selection_count=1, output_format=OutputMode.NameIndex)
     assert picker.get_selected() == []
     picker.mark_index()
     assert picker.get_selected() == [("parent", 0), ("child1", 1), ("child2", 2)]
@@ -83,8 +83,7 @@ def test_options_map_func():
     def get_node(option):
         return Node(option.get("label"))
 
-    picker = PickPacker(options, title, indicator="*", options_map_func=get_node, output_format="nameindex")
-    lines, current_line = picker.get_lines()
+    picker = PickPacker(options, title, indicator="*", options_map_func=get_node, output_format=OutputMode.NameIndex)
     lines, _ = picker.get_lines()
     assert lines == [title, "", "(*)  Select all", "( ) ├──  option1", "( ) ├──  option2", "( ) └──  option3"]
     assert picker.get_selected() == ("Select all", 0)
@@ -115,28 +114,28 @@ def test_output_format():
     assert picker.get_selected() == [(c1, 1)]
 
     # nodeindex
-    picker = PickPacker(options, title, multiselect=True, min_selection_count=1, output_format="nodeindex")
+    picker = PickPacker(options, title, multiselect=True, min_selection_count=1, output_format=OutputMode.NodeIndex)
     assert picker.get_selected() == []
     picker.move_down()
     picker.mark_index()
     assert picker.get_selected() == [(c1, 1)]
 
     # nameindex
-    picker = PickPacker(options, title, multiselect=True, min_selection_count=1, output_format="nameindex")
+    picker = PickPacker(options, title, multiselect=True, min_selection_count=1, output_format=OutputMode.NameIndex)
     assert picker.get_selected() == []
     picker.move_down()
     picker.mark_index()
     assert picker.get_selected() == [("child1", 1)]
 
     # nodeonly
-    picker = PickPacker(options, title, multiselect=True, min_selection_count=1, output_format="nodeonly")
+    picker = PickPacker(options, title, multiselect=True, min_selection_count=1, output_format=OutputMode.NodeOnly)
     assert picker.get_selected() == []
     picker.move_down()
     picker.mark_index()
     assert picker.get_selected() == [c1]
 
     # nameonly
-    picker = PickPacker(options, title, multiselect=True, min_selection_count=1, output_format="nameonly")
+    picker = PickPacker(options, title, multiselect=True, min_selection_count=1, output_format=OutputMode.NameOnly)
     assert picker.get_selected() == []
     picker.move_down()
     picker.mark_index()
@@ -156,8 +155,7 @@ def test_root_name():
     def get_node(option):
         return Node(option.get("label"))
 
-    picker = PickPacker(options, title, indicator="*", options_map_func=get_node, output_format="nameindex", root_name="EVERYTHING")
-    lines, current_line = picker.get_lines()
+    picker = PickPacker(options, title, indicator="*", options_map_func=get_node, output_format=OutputMode.NameIndex, root_name="EVERYTHING")
     lines, _ = picker.get_lines()
     assert lines == [title, "", "(*)  EVERYTHING", "( ) ├──  option1", "( ) ├──  option2", "( ) └──  option3"]
     assert picker.get_selected() == ("EVERYTHING", 0)
@@ -171,16 +169,16 @@ def test_leaves_only():
         return Node(option.get("label"))
 
     # Multiselect
-    picker = PickPacker(options, title, multiselect=True, options_map_func=get_node, output_format="nameindex", output_leaves_only=True)
+    picker = PickPacker(options, title, multiselect=True, options_map_func=get_node, output_format=OutputMode.NameIndex, output_leaves_only=True)
     assert picker.get_selected() == []
     picker.mark_index()
     assert picker.get_selected() == [("option1", 1), ("option2", 2), ("option3", 3)]
 
     # Singleselect
     with pytest.raises(ValueError):
-        picker = PickPacker(options, title, options_map_func=get_node, output_format="nameindex", output_leaves_only=True)
+        PickPacker(options, title, options_map_func=get_node, output_format=OutputMode.NameIndex, output_leaves_only=True)
     
-    picker = PickPacker(options, title, options_map_func=get_node, output_format="nameindex", output_leaves_only=True, singleselect_output_include_children=True)
+    picker = PickPacker(options, title, options_map_func=get_node, output_format=OutputMode.NameIndex, output_leaves_only=True, singleselect_output_include_children=True)
     assert picker.get_selected() == [("option1", 1), ("option2", 2), ("option3", 3)]
 
 
@@ -191,7 +189,7 @@ def test_include_children():
     def get_node(option):
         return Node(option.get("label"))
 
-    picker = PickPacker(options, title, options_map_func=get_node, output_format="nameindex", singleselect_output_include_children=True)
+    picker = PickPacker(options, title, options_map_func=get_node, output_format=OutputMode.NameIndex, singleselect_output_include_children=True)
     assert picker.get_selected() == [("Select all", 0), ("option1", 1), ("option2", 2), ("option3", 3)]
 
 

--- a/tests/test_pickpack.py
+++ b/tests/test_pickpack.py
@@ -57,7 +57,7 @@ def test_no_title():
     p1 = Node("parent", children=[c1, c2])
     options = RenderTree(p1)
     picker = PickPacker(options)
-    lines, current_line = picker.get_lines()
+    _, current_line = picker.get_lines()
     assert current_line == 1
 
 
@@ -85,6 +85,7 @@ def test_options_map_func():
 
     picker = PickPacker(options, title, indicator="*", options_map_func=get_node, output_format="nameindex")
     lines, current_line = picker.get_lines()
+    lines, _ = picker.get_lines()
     assert lines == [title, "", "(*)  Select all", "( ) ├──  option1", "( ) ├──  option2", "( ) └──  option3"]
     assert picker.get_selected() == ("Select all", 0)
 
@@ -141,11 +142,11 @@ def test_output_format():
     picker.mark_index()
     assert picker.get_selected() == ["child1"]
 
-    with pytest.raises(ValueError):
-        picker = PickPacker(options, title, multiselect=True, min_selection_count=1, output_format="invalid")
+    with pytest.raises(TypeError):
+        PickPacker(options, title, multiselect=True, min_selection_count=1, output_format="invalid")
 
     with pytest.raises(TypeError):
-        picker = PickPacker(options, title, multiselect=True, min_selection_count=1, output_format=1)
+        PickPacker(options, title, multiselect=True, min_selection_count=1, output_format=1)
 
 
 def test_root_name():
@@ -157,6 +158,7 @@ def test_root_name():
 
     picker = PickPacker(options, title, indicator="*", options_map_func=get_node, output_format="nameindex", root_name="EVERYTHING")
     lines, current_line = picker.get_lines()
+    lines, _ = picker.get_lines()
     assert lines == [title, "", "(*)  EVERYTHING", "( ) ├──  option1", "( ) ├──  option2", "( ) └──  option3"]
     assert picker.get_selected() == ("EVERYTHING", 0)
 


### PR DESCRIPTION
This quickly got out of hand.

So, instead of just using RenderTree for the nicer lines, I have

- refactored the selection methods, so they're not as long as before and better readable
- added type hints wherever possible (which is nice, because my initial PR had wrong type hints)
- added colour customization to the multi select (fixes the todo)
- added parentheses customization
- fixed some PEP8 stuff

Sorry for having all of this in one MR instead of having multiple PR for each topic.